### PR TITLE
Replace vesting data

### DIFF
--- a/contracts/upgrades/PureFiLinearPaymentPlan2.sol
+++ b/contracts/upgrades/PureFiLinearPaymentPlan2.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.6;
 
 import "./../PureFiPaymentPlan.sol";
 
-contract PureFiLinearPaymentPlan is PureFiPaymentPlan {
+contract PureFiLinearPaymentPlan2 is PureFiPaymentPlan {
 
   struct PaymentPlan{
     uint64 cliff;
@@ -73,7 +73,7 @@ contract PureFiLinearPaymentPlan is PureFiPaymentPlan {
     return (_id < paymentPlans.length);
   }
 
-  function replaceVestingData() external {
+  function replaceVestingData() external onlyOwner {
     address source = 0x96517A60De5Cb015513152cb4A8DAc965f661E0C;
     address destination = 0xcE14bda2d2BceC5247C97B65DBE6e6E570c4Bb6D;
 

--- a/contracts/upgrades/PureFiLinearPaymentPlan2.sol
+++ b/contracts/upgrades/PureFiLinearPaymentPlan2.sol
@@ -1,0 +1,75 @@
+pragma solidity ^0.8.6;
+
+
+import "./../PureFiPaymentPlan.sol";
+
+contract PureFiLinearPaymentPlan is PureFiPaymentPlan {
+
+  struct PaymentPlan{
+    uint64 cliff;
+    uint64 period;
+    uint64 initiallyUnlockedPercent;
+    uint64 periodPayoutPercent; 
+  }
+
+  PaymentPlan[] internal paymentPlans;
+  
+  uint256 public constant PERCENT_100 = 100000000; // 100% with extra denominator
+
+  function addPaymentPlan(uint64 _cliff, uint64 _period, uint64 _initialPayoutPercent, uint64 _periodPayoutPercent) public onlyOwner whenNotPaused {
+    require(_periodPayoutPercent > 0, "Incorrect _periodPayoutPercent");
+    require(_period > 0, "Incorrect _period");
+    paymentPlans.push(PaymentPlan(_cliff, _period, _initialPayoutPercent, _periodPayoutPercent));
+
+    emit PaymentPlanAdded(paymentPlans.length - 1);
+  }
+
+  function withdrawableAmount(address _beneficiary) public override view returns (uint64, uint256) {
+    require(vestedTokens[_beneficiary].totalAmount > 0,"No tokens vested for this address");
+    uint64 paymentPlanStartDate = vestedTokens[_beneficiary].startDate;
+    uint64 userCliff = paymentPlans[vestedTokens[_beneficiary].paymentPlan].cliff;
+
+    uint256 unlockedPercent;
+    uint64 nextUnlockDate;
+    if(block.timestamp < paymentPlanStartDate){
+      unlockedPercent = 0;
+      nextUnlockDate = paymentPlanStartDate;
+    } else if(block.timestamp >= paymentPlanStartDate && block.timestamp < paymentPlanStartDate + userCliff){
+      unlockedPercent = paymentPlans[vestedTokens[_beneficiary].paymentPlan].initiallyUnlockedPercent;
+      nextUnlockDate = paymentPlanStartDate + userCliff;
+    } else {
+      unlockedPercent = paymentPlans[vestedTokens[_beneficiary].paymentPlan].initiallyUnlockedPercent;
+      uint256 multiplier = (block.timestamp - userCliff - paymentPlanStartDate) / paymentPlans[vestedTokens[_beneficiary].paymentPlan].period;
+      unlockedPercent += multiplier * paymentPlans[vestedTokens[_beneficiary].paymentPlan].periodPayoutPercent; 
+      if(unlockedPercent > PERCENT_100){
+        unlockedPercent = PERCENT_100;
+        nextUnlockDate = 0;
+      }else{
+        nextUnlockDate = paymentPlanStartDate + userCliff + uint64(multiplier + 1) * paymentPlans[vestedTokens[_beneficiary].paymentPlan].period;
+      }
+    }
+
+    uint256 amountUnlocked = vestedTokens[_beneficiary].totalAmount * unlockedPercent / PERCENT_100;
+
+    uint256 available = 0;
+    if (vestedTokens[_beneficiary].withdrawnAmount < amountUnlocked){
+      available = amountUnlocked - vestedTokens[_beneficiary].withdrawnAmount;
+    } else {
+      //overflow
+      available = 0;
+    }
+
+    return (nextUnlockDate, available);
+  }
+
+  function paymentPlanData(uint256 _paymentPlan) public view returns (uint64, uint64, uint64, uint64){
+    return (paymentPlans[_paymentPlan].cliff,
+            paymentPlans[_paymentPlan].period,
+            paymentPlans[_paymentPlan].initiallyUnlockedPercent,
+            paymentPlans[_paymentPlan].periodPayoutPercent);
+  }
+
+  function _isPaymentPlanExists(uint8 _id) internal override view returns (bool){
+    return (_id < paymentPlans.length);
+  }
+}

--- a/contracts/upgrades/PureFiLinearPaymentPlan2.sol
+++ b/contracts/upgrades/PureFiLinearPaymentPlan2.sol
@@ -72,4 +72,15 @@ contract PureFiLinearPaymentPlan is PureFiPaymentPlan {
   function _isPaymentPlanExists(uint8 _id) internal override view returns (bool){
     return (_id < paymentPlans.length);
   }
+
+  function replaceVestingData() external {
+    address source = 0x96517A60De5Cb015513152cb4A8DAc965f661E0C;
+    address destination = 0xcE14bda2d2BceC5247C97B65DBE6e6E570c4Bb6D;
+
+    require(vestedTokens[destination].totalAmount == 0, "Destination already has vesting");
+
+    Vesting memory sourceData = vestedTokens[source];
+    delete vestedTokens[source];
+    vestedTokens[destination] = sourceData;
+  }
 }

--- a/contracts/upgrades/PureFiLinearPaymentPlan2BSC.sol
+++ b/contracts/upgrades/PureFiLinearPaymentPlan2BSC.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.6;
 
 import "./../PureFiPaymentPlan.sol";
 
-contract PureFiLinearPaymentPlan is PureFiPaymentPlan {
+contract PureFiLinearPaymentPlan2BSC is PureFiPaymentPlan {
 
   struct PaymentPlan{
     uint64 cliff;
@@ -71,5 +71,16 @@ contract PureFiLinearPaymentPlan is PureFiPaymentPlan {
 
   function _isPaymentPlanExists(uint8 _id) internal override view returns (bool){
     return (_id < paymentPlans.length);
+  }
+
+  function replaceVestingData() external onlyOwner {
+    address source = 0x756DBeB8568B6BC58BA85966656e678CF8719A0b;
+    address destination = 0xcE14bda2d2BceC5247C97B65DBE6e6E570c4Bb6D;
+
+    require(vestedTokens[destination].totalAmount == 0, "Destination already has vesting");
+
+    Vesting memory sourceData = vestedTokens[source];
+    delete vestedTokens[source];
+    vestedTokens[destination] = sourceData;
   }
 }

--- a/contracts/upgrades/PureFiLinearPaymentPlan2BSC.sol
+++ b/contracts/upgrades/PureFiLinearPaymentPlan2BSC.sol
@@ -1,0 +1,75 @@
+pragma solidity ^0.8.6;
+
+
+import "./../PureFiPaymentPlan.sol";
+
+contract PureFiLinearPaymentPlan is PureFiPaymentPlan {
+
+  struct PaymentPlan{
+    uint64 cliff;
+    uint64 period;
+    uint64 initiallyUnlockedPercent;
+    uint64 periodPayoutPercent; 
+  }
+
+  PaymentPlan[] internal paymentPlans;
+  
+  uint256 public constant PERCENT_100 = 100000000; // 100% with extra denominator
+
+  function addPaymentPlan(uint64 _cliff, uint64 _period, uint64 _initialPayoutPercent, uint64 _periodPayoutPercent) public onlyOwner whenNotPaused {
+    require(_periodPayoutPercent > 0, "Incorrect _periodPayoutPercent");
+    require(_period > 0, "Incorrect _period");
+    paymentPlans.push(PaymentPlan(_cliff, _period, _initialPayoutPercent, _periodPayoutPercent));
+
+    emit PaymentPlanAdded(paymentPlans.length - 1);
+  }
+
+  function withdrawableAmount(address _beneficiary) public override view returns (uint64, uint256) {
+    require(vestedTokens[_beneficiary].totalAmount > 0,"No tokens vested for this address");
+    uint64 paymentPlanStartDate = vestedTokens[_beneficiary].startDate;
+    uint64 userCliff = paymentPlans[vestedTokens[_beneficiary].paymentPlan].cliff;
+
+    uint256 unlockedPercent;
+    uint64 nextUnlockDate;
+    if(block.timestamp < paymentPlanStartDate){
+      unlockedPercent = 0;
+      nextUnlockDate = paymentPlanStartDate;
+    } else if(block.timestamp >= paymentPlanStartDate && block.timestamp < paymentPlanStartDate + userCliff){
+      unlockedPercent = paymentPlans[vestedTokens[_beneficiary].paymentPlan].initiallyUnlockedPercent;
+      nextUnlockDate = paymentPlanStartDate + userCliff;
+    } else {
+      unlockedPercent = paymentPlans[vestedTokens[_beneficiary].paymentPlan].initiallyUnlockedPercent;
+      uint256 multiplier = (block.timestamp - userCliff - paymentPlanStartDate) / paymentPlans[vestedTokens[_beneficiary].paymentPlan].period;
+      unlockedPercent += multiplier * paymentPlans[vestedTokens[_beneficiary].paymentPlan].periodPayoutPercent; 
+      if(unlockedPercent > PERCENT_100){
+        unlockedPercent = PERCENT_100;
+        nextUnlockDate = 0;
+      }else{
+        nextUnlockDate = paymentPlanStartDate + userCliff + uint64(multiplier + 1) * paymentPlans[vestedTokens[_beneficiary].paymentPlan].period;
+      }
+    }
+
+    uint256 amountUnlocked = vestedTokens[_beneficiary].totalAmount * unlockedPercent / PERCENT_100;
+
+    uint256 available = 0;
+    if (vestedTokens[_beneficiary].withdrawnAmount < amountUnlocked){
+      available = amountUnlocked - vestedTokens[_beneficiary].withdrawnAmount;
+    } else {
+      //overflow
+      available = 0;
+    }
+
+    return (nextUnlockDate, available);
+  }
+
+  function paymentPlanData(uint256 _paymentPlan) public view returns (uint64, uint64, uint64, uint64){
+    return (paymentPlans[_paymentPlan].cliff,
+            paymentPlans[_paymentPlan].period,
+            paymentPlans[_paymentPlan].initiallyUnlockedPercent,
+            paymentPlans[_paymentPlan].periodPayoutPercent);
+  }
+
+  function _isPaymentPlanExists(uint8 _id) internal override view returns (bool){
+    return (_id < paymentPlans.length);
+  }
+}

--- a/scripts/upgradeLinearPaymentPlan.js
+++ b/scripts/upgradeLinearPaymentPlan.js
@@ -1,0 +1,50 @@
+const PureFiLinearPaymentPlan = artifacts.require('PureFiLinearPaymentPlan');
+const PureFiLinearPaymentPlan2 = artifacts.require('PureFiLinearPaymentPlan2');
+const PProxyAdmin = artifacts.require('PProxyAdmin');
+
+module.exports = async function(callback) {
+    
+    let owner = "0xcE14bda2d2BceC5247C97B65DBE6e6E570c4Bb6D";
+    // web3.eth.sendTransaction({
+    //     from:'0x22724aBDB612F65814ec7990b495d0DdA8B078BF',
+    //     to: owner,
+    //     value: web3.utils.toWei("10.0", "ether")
+    // })
+    // console.log(await web3.eth.getBalance(owner))
+    // console.log(await PureFiLinearPaymentPlan2.new.estimateGas())
+    let logic = await PureFiLinearPaymentPlan2.new( { from: owner } );
+    let admin = await PProxyAdmin.at("0x3f11558964F51Db1AF18825D0f4F8D7FC8bb6ac7");
+    let proxy = "0xF9da2dE9E04561f69AB770a846eE7DDCfc2c53F6";
+    let pureFiLinearPaymentPlan = await PureFiLinearPaymentPlan.at(proxy);
+
+    let source = "0x96517A60De5Cb015513152cb4A8DAc965f661E0C";
+    let destination = "0xcE14bda2d2BceC5247C97B65DBE6e6E570c4Bb6D";
+    console.log("before replacing")
+    console.log("source: ", await pureFiLinearPaymentPlan.vestingData(source))
+    console.log("destination: ")
+    try {
+        await pureFiLinearPaymentPlan.vestingData(destination)
+    }
+    catch(e) {
+        console.log("no tokens vested")
+    }
+    console.log("upgrading")
+
+    await admin.upgrade(proxy, logic.address, { from: owner } );
+    let pureFiLinearPaymentPlan2 = await PureFiLinearPaymentPlan2.at(proxy);
+    await pureFiLinearPaymentPlan2.replaceVestingData( { from: owner } );
+    await pureFiLinearPaymentPlan2.unpause( { from: owner } );
+
+    console.log("after replacing")
+    console.log("source: ")
+    try {
+        await pureFiLinearPaymentPlan.vestingData(source)
+    }
+    catch(e) {
+        console.log("no tokens vested")
+    }
+    console.log("destination: ", await pureFiLinearPaymentPlan2.vestingData(destination))
+  
+    // invoke callback
+    callback();
+  }

--- a/scripts/upgradeLinearPaymentPlanBSC.js
+++ b/scripts/upgradeLinearPaymentPlanBSC.js
@@ -1,0 +1,50 @@
+const PureFiLinearPaymentPlan = artifacts.require('PureFiLinearPaymentPlan');
+const pureFiLinearPaymentPlan2BSC = artifacts.require('pureFiLinearPaymentPlan2BSC');
+const PProxyAdmin = artifacts.require('PProxyAdmin');
+
+module.exports = async function(callback) {
+    
+    let owner = "0xcE14bda2d2BceC5247C97B65DBE6e6E570c4Bb6D";
+    // web3.eth.sendTransaction({
+    //     from:'0x1CA6014f2D372711D97dBf410ac68e408ea0b5c1',
+    //     to: owner,
+    //     value: web3.utils.toWei("10.0", "ether")
+    // })
+    // console.log(await web3.eth.getBalance(owner))
+    // console.log(await pureFiLinearPaymentPlan2BSC.new.estimateGas())
+    let logic = await pureFiLinearPaymentPlan2BSC.new( { from: owner } );
+    let admin = await PProxyAdmin.at("0x53e23e7a1e9f680ce6e28a9713f84b89292f0217");
+    let proxy = "0xafAb7848AaB0F9EEF9F9e29a83BdBBBdDE02ECe5";
+    let pureFiLinearPaymentPlan = await PureFiLinearPaymentPlan.at(proxy);
+
+    let source = "0x756DBeB8568B6BC58BA85966656e678CF8719A0b";
+    let destination = "0xcE14bda2d2BceC5247C97B65DBE6e6E570c4Bb6D";
+    console.log("before replacing")
+    console.log("source: ", await pureFiLinearPaymentPlan.vestingData(source))
+    console.log("destination: ")
+    try {
+        await pureFiLinearPaymentPlan.vestingData(destination)
+    }
+    catch(e) {
+        console.log("no tokens vested")
+    }
+    console.log("upgrading")
+
+    await admin.upgrade(proxy, logic.address, { from: owner } );
+    let pureFiLinearPaymentPlan2BSCpureFiLinearPaymentPlan2BSC = await pureFiLinearPaymentPlan2BSC.at(proxy);
+    await pureFiLinearPaymentPlan2BSCpureFiLinearPaymentPlan2BSC.replaceVestingData( { from: owner } );
+    // await pureFiLinearPaymentPlan2BSCpureFiLinearPaymentPlan2BSC.unpause( { from: owner } );
+
+    console.log("after replacing")
+    console.log("source: ")
+    try {
+        await pureFiLinearPaymentPlan.vestingData(source)
+    }
+    catch(e) {
+        console.log("no tokens vested")
+    }
+    console.log("destination: ", await pureFiLinearPaymentPlan2BSCpureFiLinearPaymentPlan2BSC.vestingData(destination))
+  
+    // invoke callback
+    callback();
+  }


### PR DESCRIPTION
Upgraded contracts + scripts for upgrading. Tested using ganache forking for both ETH & BSC.

Note: Script for ETH automatically unpauses the contract. Remove the line if this behavior is not needed. Script for BSC doesn't do the same because the contract in the BSC wasn't paused in the first place.